### PR TITLE
binder: Add readuInt64() symbol for LG RIL compatibility

### DIFF
--- a/include/binder/Parcel.h
+++ b/include/binder/Parcel.h
@@ -154,6 +154,9 @@ public:
     status_t            readInt32(int32_t *pArg) const;
     int64_t             readInt64() const;
     status_t            readInt64(int64_t *pArg) const;
+#ifdef NEEDS_LGE_RIL_SYMBOLS
+    status_t            readuInt64(uint64_t *pArg) const;
+#endif
     float               readFloat() const;
     status_t            readFloat(float *pArg) const;
     double              readDouble() const;

--- a/libs/binder/Parcel.cpp
+++ b/libs/binder/Parcel.cpp
@@ -1045,6 +1045,15 @@ int64_t Parcel::readInt64() const
     return readAligned<int64_t>();
 }
 
+
+#ifdef NEEDS_LGE_RIL_SYMBOLS
+status_t Parcel::readuInt64(uint64_t *pArg) const
+{
+    return readAligned(pArg);
+}
+#endif
+
+
 status_t Parcel::readPointer(uintptr_t *pArg) const
 {
     status_t ret;


### PR DESCRIPTION
 * LG RIL libs need readuInt64() (I have no idea why, blame LG)
 * Instead of having to use liblgderp.so we can just set
   NEEDS_LGE_RIL_SYMBOLS to incorporate the symbols into the system
 * Original commits:
   - http://review.cyanogenmod.org/#/c/61459/
   - http://review.cyanogenmod.org/#/c/61460/

Change-Id: I9069dbde7a5800c538b135963b4cf7365a1b3f80