### PR TITLE
sensorservice: Don't replace HAL orientation sensor

### DIFF
--- a/services/sensorservice/SensorService.cpp
+++ b/services/sensorservice/SensorService.cpp
@@ -149,10 +149,6 @@ void SensorService::onFirstRef()
                     if (orientationIndex == -1) {
                         // some sensor HALs don't provide an orientation sensor.
                         mUserSensorList.add(aSensor);
-                    } else {
-                        // if we are doing our own rotation-vector, also add
-                        // the orientation sensor and remove the HAL provided one.
-                        mUserSensorList.replaceAt(aSensor, orientationIndex);
                     }
                 }
 


### PR DESCRIPTION
* Previously HAL orientation sensor would always be replaced if the HAL
  did not provide a rotation vector sensor as well. Practically no HAL
  does, so the virtual sensor would always replace it.
* Add the virtual sensor only if the HAL does not provide it.

Change-Id: I50ad2cd6c60b53eddc4c6854997ec2e3dbff0d1a